### PR TITLE
Add install script for curl based installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ You can install this via the command-line with either `curl`, `wget` or another 
 
 | Method    | Command                                                                                           |
 | :-------- | :------------------------------------------------------------------------------------------------ |
-| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/d2verb/zigenv/master/zigenv-init.sh)"` |
-| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/d2verb/zigenv/master/zigenv-init..sh)"`   |
-| **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/d2verb/zigenv/master/zigenv-init.sh)"` |
+| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)"` |
+| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init..sh)"`   |
+| **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)"` |
 
 ## Usage
 Install new zig version.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ You can install this via the command-line with either `curl`, `wget` or another 
 
 | Method    | Command                                                                                           |
 | :-------- | :------------------------------------------------------------------------------------------------ |
-| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)" && . $HOME/zigenv/zigenv-init.sh && zigenv install 0.13.0 && zigenv change 0.13.0` |
-| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init..sh)" && . $HOME/zigenv/zigenv-init.sh && zigenv install 0.13.0 && zigenv change 0.13.0`   |
-| **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)" && . $HOME/zigenv/zigenv-init.sh && zigenv install 0.13.0 && zigenv change 0.13.0` |
+| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)" && . $HOME/.zigenv/zigenv-init.sh && zigenv install 0.13.0 && zigenv change 0.13.0` |
+| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init..sh)" && . $HOME/.zigenv/zigenv-init.sh && zigenv install 0.13.0 && zigenv change 0.13.0`   |
+| **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)" && . $HOME/.zigenv/zigenv-init.sh && zigenv install 0.13.0 && zigenv change 0.13.0` |
 
 ## Usage
 Install new zig version.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 zigenv is a tool to manage multiple zig versions.
 
 ## Install
-```
-$ git clone https://github.com/d2verb/zigenv ~/.zigenv
-```
-Add the following to your .bash_profile or .bashrc.
-```
-export ZIGENV_ROOT=$HOME/.zigenv
-export PATH=$ZIGENV_ROOT/bin:$ZIGENV_ROOT/shims:$PATH
-```
+
+zigenv is installed by running one of the following commands in your terminal. 
+You can install this via the command-line with either `curl`, `wget` or another similar tool.
+
+| Method    | Command                                                                                           |
+| :-------- | :------------------------------------------------------------------------------------------------ |
+| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/d2verb/zigenv/master/zigenv-init.sh)"` |
+| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/d2verb/zigenv/master/zigenv-init..sh)"`   |
+| **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/d2verb/zigenv/master/zigenv-init.sh)"` |
+
 ## Usage
 Install new zig version.
 ```

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ You can install this via the command-line with either `curl`, `wget` or another 
 
 | Method    | Command                                                                                           |
 | :-------- | :------------------------------------------------------------------------------------------------ |
-| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)"` |
-| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init..sh)"`   |
-| **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)"` |
+| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)" && . $HOME/zigenv/zigenv-init.sh && zigenv install 0.13.0 && zigenv change 0.13.0` |
+| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init..sh)" && . $HOME/zigenv/zigenv-init.sh && zigenv install 0.13.0 && zigenv change 0.13.0`   |
+| **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/melhindi/zigenv/master/zigenv-init.sh)" && . $HOME/zigenv/zigenv-init.sh && zigenv install 0.13.0 && zigenv change 0.13.0` |
 
 ## Usage
 Install new zig version.

--- a/execs/zigenv
+++ b/execs/zigenv
@@ -5,35 +5,35 @@ export PATH=$ZIGENV_ROOT/execs:$PATH
 CURRENT_VERSION=$(cat $ZIGENV_ROOT/VERSION)
 
 if [ $# -eq 0 ]; then
-	exec zigenv-help
-	exit 0
+ exec zigenv-help
+ exit 0
 fi
 
 COMMAND=$1
 shift
 case $COMMAND in
-help)
-	exec zigenv-help
-	;;
-change)
-	exec zigenv-change "$@"
-	;;
-install)
-	exec zigenv-install "$@"
-	;;
-uninstall)
-	exec zigenv-uninstall "$@"
-	;;
-version)
-	echo $(cat "$ZIGENV_ROOT/VERSION")
-	;;
-versions)
-	for version in $(ls "$ZIGENV_ROOT/versions"); do
-		if [ "$version" = "$CURRENT_VERSION" ]; then
-			echo "* $version"
-		else
-			echo "  $version"
-		fi
-	done
-	;;
+  help)
+    exec zigenv-help
+    ;;
+  change)
+    exec zigenv-change "$@"
+    ;;
+  install)
+    exec zigenv-install "$@"
+    ;;
+  uninstall)
+    exec zigenv-uninstall "$@"
+    ;;
+  version)
+    echo $(cat "$ZIGENV_ROOT/VERSION")
+    ;;
+  versions)
+    for version in $(ls "$ZIGENV_ROOT/versions"); do
+      if [ "$version" = "$CURRENT_VERSION" ]; then
+         echo "* $version"
+      else
+         echo "  $version"
+      fi
+    done
+    ;;
 esac

--- a/execs/zigenv
+++ b/execs/zigenv
@@ -5,35 +5,35 @@ export PATH=$ZIGENV_ROOT/execs:$PATH
 CURRENT_VERSION=$(cat $ZIGENV_ROOT/VERSION)
 
 if [ $# -eq 0 ]; then
-  exec zigenv-help
-  exit 0
+	exec zigenv-help
+	exit 0
 fi
 
 COMMAND=$1
 shift
 case $COMMAND in
-  help)
-    exec zigenv-help
-    ;;
-  change)
-    exec zigenv-change $@
-    ;;
-  install)
-    exec zigenv-install $@
-    ;;
-  uninstall)
-    exec zigenv-uninstall $@
-    ;;
-  version)
-    echo $(cat $ZIGENV_ROOT/VERSION)
-    ;;
-  versions)
-    for version in $(ls $ZIGENV_ROOT/versions); do
-      if [ $version = $CURRENT_VERSION ]; then
-        echo "* $version"
-      else
-        echo "  $version"
-      fi
-    done
-    ;;
+help)
+	exec zigenv-help
+	;;
+change)
+	exec zigenv-change "$@"
+	;;
+install)
+	exec zigenv-install "$@"
+	;;
+uninstall)
+	exec zigenv-uninstall "$@"
+	;;
+version)
+	echo $(cat "$ZIGENV_ROOT/VERSION")
+	;;
+versions)
+	for version in $(ls "$ZIGENV_ROOT/versions"); do
+		if [ "$version" = "$CURRENT_VERSION" ]; then
+			echo "* $version"
+		else
+			echo "  $version"
+		fi
+	done
+	;;
 esac

--- a/execs/zigenv-install
+++ b/execs/zigenv-install
@@ -4,61 +4,60 @@ set -eu
 URLS=$(curl -Lso- https://ziglang.org/download/index.json | jq -r '.[] | ."x86_64-linux" | .tarball')
 
 url2version() {
-  VERSION=$(echo $1 | grep -Po '/(builds|\d+\.\d+\.\d+)/')
-  echo ${VERSION:1:-1}
+   VERSION=$(echo $1 | grep -Po '/(builds|\d+\.\d+\.\d+)/')
+   echo ${VERSION:1:-1}
 }
 
 install() {
-  URL=$1
-  INSTALL_PATH=$ZIGENV_ROOT/versions/$(url2version $URL)
-  mkdir -p $INSTALL_PATH
-  pushd $INSTALL_PATH
-  wget $URL
-  TAR_FILE=$(ls)
-  tar xvf $TAR_FILE && rm $TAR_FILE
-  ZIG_DIR=$(ls)
-  mv $ZIG_DIR/* .
-  rm -rf $ZIG_DIR
+   URL=$1
+   INSTALL_PATH=$ZIGENV_ROOT/versions/$(url2version $URL)
+   mkdir -p $INSTALL_PATH
+   pushd $INSTALL_PATH
+   wget $URL
+   TAR_FILE=$(ls)
+   tar xf $TAR_FILE && rm $TAR_FILE
+   ZIG_DIR=$(ls | head -1)
+   mv $ZIG_DIR/* .
+   rm -rf $ZIG_DIR
 }
 
 if [ $# -eq 0 ]; then
-  echo "Usage: zigenv install <version>"
-  echo "Available zig versions:"
-  for url in $URLS; do
-    echo "   $(url2version $url)"
-  done
-  exit 1
+   echo "Usage: zigenv install <version>"
+   echo "Available zig versions:"
+   for url in $URLS; do
+      echo "   $(url2version $url)"
+   done
+   exit 1
 fi
 
 for url in $URLS; do
-  if [[ $url == */$1/* ]]; then
-    echo "Version $1 found. $url"
-    echo "Install this version? [Y/n]"
-    read YN
-    case $(echo $YN | tr y Y) in
+   if [[ $url == */$1/* ]]; then
+      echo "Version $1 found. $url"
+      echo "Install this version? [Y/n]"
+      read YN
+      case $(echo $YN | tr y Y) in
       "" | Y*)
-        echo "Installing..."
+         echo "Installing..."
 
-        for version in $(ls $ZIGENV_ROOT/versions); do
-          if [ $version = $1 ]; then
-            echo "Version $version is already installed."
-            echo "Reinstall? [Y/n]"
-            read YN
-            case $(echo $YN | tr y Y) in
-              "" | Y*)
-                rm -rf $ZIGENV_ROOT/versions/$version
-                ;;
-              *)
-                exit 0
-                ;;
-            esac
-          fi
-        done
+         for version in $(ls $ZIGENV_ROOT/versions); do
+            if [ $version = $1 ]; then
+               echo "Version $version is already installed."
+               echo "Reinstall? [Y/n]"
+               read YN
+               case $(echo $YN | tr y Y) in
+               "" | Y*)
+                  rm -rf $ZIGENV_ROOT/versions/$version
+                  ;;
+               *)
+                  exit 0
+                  ;;
+               esac
+            fi
+         done
 
-        install $url
-        ;;
-      *)
-        ;;
-    esac
-  fi
+         install $url
+         ;;
+      *) ;;
+      esac
+   fi
 done

--- a/zigenv-init.sh
+++ b/zigenv-init.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+# Function to clone the zigenv repository
+clone_zigenv() {
+	ZIGENV_REPO="https://github.com/melhindi/zigenv"
+	ZIGENV_DIR="$HOME/.zigenv"
+	git clone "$ZIGENV_REPO" "$ZIGENV_DIR"
+}
+
+# Function to append zigenv initialization to a file
+append_zigenv_init() {
+	PROFILE_FILE="$1"
+	case "$SHELL" in
+	*/fish)
+		# For Fish shell, use fish_user_paths for PATH update
+		echo 'set -gx ZIGENV_ROOT "$HOME/.zigenv"' >>"$PROFILE_FILE"
+		echo 'set -gx fish_user_paths "$ZIGENV_ROOT/bin" "$ZIGENV_ROOT/shims" $fish_user_paths' >>"$PROFILE_FILE"
+		;;
+	*)
+		# For other shells, use the export command
+		{
+			echo '# Initialize zigenv'
+			echo 'ZIGENV_ROOT="$HOME/.zigenv"'
+			echo 'PATH="$ZIGENV_ROOT/bin:$ZIGENV_ROOT/shims:$PATH"'
+			echo 'export ZIGENV_ROOT PATH'
+		} >>"$PROFILE_FILE"
+		;;
+	esac
+}
+
+# Function to detect the shell and choose the appropriate profile file
+choose_profile_file() {
+	case "$SHELL" in
+	*/bash)
+		[ -f "$HOME/.bash_profile" ] && echo "$HOME/.bash_profile" || echo "$HOME/.bashrc"
+		;;
+	*/zsh)
+		[ -f "$HOME/.zprofile" ] && echo "$HOME/.zprofile" || echo "$HOME/.zshrc"
+		;;
+	*/fish)
+		echo "$HOME/.config/fish/config.fish"
+		;;
+	*/ksh)
+		[ -f "$HOME/.kshrc" ] && echo "$HOME/.kshrc" || echo "$HOME/.profile"
+		;;
+	*)
+		echo "$HOME/.profile"
+		;;
+	esac
+}
+
+# Function to source the profile file
+source_profile_file() {
+	PROFILE_FILE="$1"
+	case "$SHELL" in
+	*/fish)
+		# Source config.fish for Fish shell
+		fish -c "source $PROFILE_FILE"
+		;;
+	*)
+		# Source the profile for other shells
+		# We cannot source the file directly from a script running in a different process,
+		# so we print a message instructing the user to do it manually.
+		echo "Please run the following command to apply the changes:"
+		echo ". \"$PROFILE_FILE\""
+		;;
+	esac
+}
+
+# Main function to install zigenv
+install_zigenv() {
+	clone_zigenv
+	PROFILE_FILE=$(choose_profile_file)
+	append_zigenv_init "$PROFILE_FILE"
+	source_profile_file "$PROFILE_FILE"
+	echo "zigenv installed and initialized in $PROFILE_FILE"
+}
+
+# Execute the main function
+install_zigenv

--- a/zigenv-init.sh
+++ b/zigenv-init.sh
@@ -2,78 +2,81 @@
 
 # Function to clone the zigenv repository
 clone_zigenv() {
-	ZIGENV_REPO="https://github.com/melhindi/zigenv"
-	ZIGENV_DIR="$HOME/.zigenv"
-	git clone "$ZIGENV_REPO" "$ZIGENV_DIR"
+   ZIGENV_REPO="https://github.com/melhindi/zigenv"
+   ZIGENV_DIR="$HOME/.zigenv"
+   [ ! -d "$ZIGENV_DIR" ] && git clone "$ZIGENV_REPO" "$ZIGENV_DIR"
 }
 
 # Function to append zigenv initialization to a file
 append_zigenv_init() {
-	PROFILE_FILE="$1"
-	case "$SHELL" in
-	*/fish)
-		# For Fish shell, use fish_user_paths for PATH update
-		echo 'set -gx ZIGENV_ROOT "$HOME/.zigenv"' >>"$PROFILE_FILE"
-		echo 'set -gx fish_user_paths "$ZIGENV_ROOT/bin" "$ZIGENV_ROOT/shims" $fish_user_paths' >>"$PROFILE_FILE"
-		;;
-	*)
-		# For other shells, use the export command
-		{
-			echo '# Initialize zigenv'
-			echo 'ZIGENV_ROOT="$HOME/.zigenv"'
-			echo 'PATH="$ZIGENV_ROOT/bin:$ZIGENV_ROOT/shims:$PATH"'
-			echo 'export ZIGENV_ROOT PATH'
-		} >>"$PROFILE_FILE"
-		;;
-	esac
+   PROFILE_FILE="$1"
+   case "$SHELL" in
+   */fish)
+      # For Fish shell, use fish_user_paths for PATH update
+      echo 'set -gx ZIGENV_ROOT "$HOME/.zigenv"' >>"$PROFILE_FILE"
+      echo 'set -gx fish_user_paths "$ZIGENV_ROOT/bin" "$ZIGENV_ROOT/shims" $fish_user_paths' >>"$PROFILE_FILE"
+      ;;
+   *)
+      # For other shells, use the export command
+      {
+         echo '# Initialize zigenv'
+         echo 'ZIGENV_ROOT="$HOME/.zigenv"'
+         echo 'PATH="$ZIGENV_ROOT/bin:$ZIGENV_ROOT/shims:$PATH"'
+         echo 'export ZIGENV_ROOT PATH'
+      } >>"$PROFILE_FILE"
+      ;;
+   esac
 }
 
 # Function to detect the shell and choose the appropriate profile file
 choose_profile_file() {
-	case "$SHELL" in
-	*/bash)
-		[ -f "$HOME/.bashrc" ] && echo "$HOME/.bashrc" || echo "$HOME/.bash_profile"
-		;;
-	*/zsh)
-		[ -f "$HOME/.zshrc" ] && echo "$HOME/.zshrc" || echo "$HOME/.zprofile"
-		;;
-	*/fish)
-		echo "$HOME/.config/fish/config.fish"
-		;;
-	*/ksh)
-		[ -f "$HOME/.kshrc" ] && echo "$HOME/.kshrc" || echo "$HOME/.profile"
-		;;
-	*)
-		echo "$HOME/.profile"
-		;;
-	esac
+   case "$SHELL" in
+   */bash)
+      [ -f "$HOME/.bashrc" ] && echo "$HOME/.bashrc" || echo "$HOME/.bash_profile"
+      ;;
+   */zsh)
+      [ -f "$HOME/.zshrc" ] && echo "$HOME/.zshrc" || echo "$HOME/.zprofile"
+      ;;
+   */fish)
+      echo "$HOME/.config/fish/config.fish"
+      ;;
+   */ksh)
+      [ -f "$HOME/.kshrc" ] && echo "$HOME/.kshrc" || echo "$HOME/.profile"
+      ;;
+   *)
+      echo "$HOME/.profile"
+      ;;
+   esac
 }
 
 # Function to source the profile file
 source_profile_file() {
-	PROFILE_FILE="$1"
-	case "$SHELL" in
-	*/fish)
-		# Source config.fish for Fish shell
-		fish -c "source $PROFILE_FILE"
-		;;
-	*)
-		# Source the profile for other shells
-		# We cannot source the file directly from a script running in a different process,
-		# so we print a message instructing the user to do it manually.
-		echo "Please run the following command to apply the changes:"
-		echo ". \"$PROFILE_FILE\""
-		;;
-	esac
+   PROFILE_FILE="$1"
+   case "$SHELL" in
+   */fish)
+      # Source config.fish for Fish shell
+      fish -c "source $PROFILE_FILE"
+      ;;
+   *)
+      # Source the profile for other shells
+      # We cannot source the file directly from a script running in a different process,
+      # so we print a message instructing the user to do it manually.
+      echo "If required, please run the following command to apply the changes:"
+      echo ". \"$PROFILE_FILE\""
+      . $PROFILE_FILE
+      ;;
+   esac
 }
 
 # Main function to install zigenv
 install_zigenv() {
-	clone_zigenv
-	PROFILE_FILE=$(choose_profile_file)
-	append_zigenv_init "$PROFILE_FILE"
-	source_profile_file "$PROFILE_FILE"
-	echo "zigenv installed and initialized in $PROFILE_FILE"
+   clone_zigenv
+   PROFILE_FILE=$(choose_profile_file)
+   if ! grep -q ZIGENV_ROOT $PROFILE_FILE; then
+      append_zigenv_init "$PROFILE_FILE"
+   fi
+   source_profile_file "$PROFILE_FILE"
+   echo "zigenv installed and initialized in $PROFILE_FILE"
 }
 
 # Execute the main function

--- a/zigenv-init.sh
+++ b/zigenv-init.sh
@@ -32,10 +32,10 @@ append_zigenv_init() {
 choose_profile_file() {
 	case "$SHELL" in
 	*/bash)
-		[ -f "$HOME/.bash_profile" ] && echo "$HOME/.bash_profile" || echo "$HOME/.bashrc"
+		[ -f "$HOME/.bashrc" ] && echo "$HOME/.bashrc" || echo "$HOME/.bash_profile"
 		;;
 	*/zsh)
-		[ -f "$HOME/.zprofile" ] && echo "$HOME/.zprofile" || echo "$HOME/.zshrc"
+		[ -f "$HOME/.zshrc" ] && echo "$HOME/.zshrc" || echo "$HOME/.zprofile"
 		;;
 	*/fish)
 		echo "$HOME/.config/fish/config.fish"


### PR DESCRIPTION
Hi,
I like your tool since it makes installing different zig versions easy.
To have a similar experience as with rustup, I added a simple shell script that allows users to install zigenv using a curl one-liner.